### PR TITLE
fix: remove base path from Astro configuration for correct deployment

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -9,5 +9,4 @@ export default defineConfig({
     plugins: [tailwindcss()]
   },
   site: 'https://impetus-indomitus.github.io',
-  base: '/website',
 });


### PR DESCRIPTION
This pull request includes a small change to the `astro.config.mjs` file. The change removes the `base: '/website'` configuration, simplifying the site's base URL settings.